### PR TITLE
Fix numeric escape followed by digits in string generator

### DIFF
--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -284,8 +284,8 @@ fn escape(character: char) -> String {
         '\u{B}' => "\\v".to_owned(),
         '\u{C}' => "\\f".to_owned(),
         _ => {
-            if character.len_utf8() == 1 {
-                format!("\\{}", character as u8)
+            if character.is_ascii() {
+                format!("\\x{:02x}", character as u8)
             } else {
                 format!("\\u{{{:x}}}", character as u32)
             }
@@ -445,8 +445,8 @@ mod test {
             backslash("\\") => "'\\\\'",
             single_quote("'") => "\"'\"",
             double_quote("\"") => "'\"'",
-            null("\0") => "'\\0'",
-            escape("\u{1B}") => "'\\27'",
+            null("\0") => "'\\x00'",
+            escape("\u{1B}") => "'\\x1b'",
             extended_ascii("\u{C3}") => "'\\u{c3}'",
             unicode("\u{25C1}") => "'\\u{25c1}'",
             escape_degree_symbol("°") => "'\\u{b0}'",
@@ -462,6 +462,7 @@ mod test {
 
             large_multiline_with_unicode("\nooof\nooof\nooof\nooof\nooof\nooof\nooof\nooof\noof\u{10FFFF}")
                 => "'\\nooof\\nooof\\nooof\\nooof\\nooof\\nooof\\nooof\\nooof\\noof\\u{10ffff}'",
+            escape_followed_by_digit("\u{1f}8") => "'\\x1f8'",
         );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -326,6 +326,52 @@ fn run_process_single_file_custom_config_command_deprecated_config_path() {
 }
 
 #[test]
+fn process_dense_preserves_escape_sequence() {
+    Context::default()
+        .write_file("src/init.lua", "print(\"\\x1f8\")\n")
+        .arg("process")
+        .arg("--format")
+        .arg("dense")
+        .arg("src")
+        .arg("out")
+        .expect_success()
+        .snapshot_file(
+            "process_dense_preserves_escape_sequence_out",
+            "out/init.lua",
+        );
+}
+
+#[test]
+fn process_readable_preserves_escape_sequence() {
+    Context::default()
+        .write_file("src/init.lua", "print(\"\\x1f8\")\n")
+        .arg("process")
+        .arg("--format")
+        .arg("readable")
+        .arg("src")
+        .arg("out")
+        .expect_success()
+        .snapshot_file(
+            "process_readable_preserves_escape_sequence_out",
+            "out/init.lua",
+        );
+}
+
+#[test]
+fn minify_preserves_escape_sequence() {
+    Context::default()
+        .write_file("src/init.lua", "print(\"\\x1f8\")\n")
+        .arg("minify")
+        .arg("src")
+        .arg("out")
+        .expect_success()
+        .snapshot_file(
+            "minify_preserves_escape_sequence_out",
+            "out/init.lua",
+        );
+}
+
+#[test]
 fn run_convert_command_on_json_file_with_output() {
     Context::default()
         .write_file("data.json", "{ \"property\": true }")

--- a/tests/snapshots/minify_preserves_escape_sequence_out.snap
+++ b/tests/snapshots/minify_preserves_escape_sequence_out.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+snapshot_kind: text
+---
+print('\x1f8')

--- a/tests/snapshots/process_dense_preserves_escape_sequence_out.snap
+++ b/tests/snapshots/process_dense_preserves_escape_sequence_out.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+snapshot_kind: text
+---
+print'\x1f8'

--- a/tests/snapshots/process_readable_preserves_escape_sequence_out.snap
+++ b/tests/snapshots/process_readable_preserves_escape_sequence_out.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+snapshot_kind: text
+---
+print'\x1f8'


### PR DESCRIPTION
## Summary
- ensure ASCII characters are escaped with two-digit hex to avoid merging with following digits
- expand string escaping tests and add regression for `"\x1f8"`
- add CLI tests to verify `process` (dense/readable) and `minify` handle the escape correctly

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893e988cbf48326801dc62eb1ef08e8